### PR TITLE
ログイン処理の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1681,6 +1681,11 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hookform/resolvers": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.8.0.tgz",
+      "integrity": "sha512-ALlr0Bg6zDHdRsdqkwfWGPMnIxP4hqMRPvFDHp7lWXQeA7rKykto3cWqQQh1s0PzX043RHwMB6OHVPMwFJqwxg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2039,6 +2044,18 @@
       "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
       "requires": {
         "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.60",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.60.tgz",
+      "integrity": "sha512-fadlYsPJF+0fx2lRuyqAuJj7hAS1tLDdIEEdov5jlrpb5pp4b+mRDUqQTUxi4inRZHS1bEXpU8QWUhO6xX88aA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@material-ui/styles": {
@@ -2625,6 +2642,11 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw=="
     },
     "@types/long": {
       "version": "4.0.1",
@@ -9366,6 +9388,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
@@ -9808,6 +9835,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.1.25",
@@ -11681,6 +11713,11 @@
         }
       }
     },
+    "property-expr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
+    },
     "protobufjs": {
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
@@ -11702,9 +11739,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "16.7.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-          "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A=="
+          "version": "16.7.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.2.tgz",
+          "integrity": "sha512-TbG4TOx9hng8FKxaVrCisdaxKxqEwJ3zwHoCWXZ0Jw6mnvTInpaB99/2Cy4+XxpXtjNv9/TgfGSvZFyfV/t8Fw=="
         }
       }
     },
@@ -14240,6 +14277,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -16113,6 +16155,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "yup": {
+      "version": "0.32.9",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.9.tgz",
+      "integrity": "sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@types/lodash": "^4.14.165",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.15",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hookform/resolvers": "^2.8.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
+    "@material-ui/lab": "^4.0.0-alpha.60",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
 import React, { VFC } from "react";
 import { BrowserRouter } from "react-router-dom";
+import { SimpleSnackbar } from "./components/atoms/SimpleSnackbar";
+import { LoginUserProvider } from "./providers/LoginUserProvider";
+import { SnackbarProvider } from "./providers/SnackbarProvider";
 import { Router } from "./router/Router";
 
 const App: VFC = () => {
   return (
     <BrowserRouter>
-      <Router />
+      <LoginUserProvider>
+        <SnackbarProvider>
+          <SimpleSnackbar />
+          <Router />
+        </SnackbarProvider>
+      </LoginUserProvider>
     </BrowserRouter>
   );
 };

--- a/src/components/atoms/SimpleSnackbar.tsx
+++ b/src/components/atoms/SimpleSnackbar.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from "react";
+import Snackbar from "@material-ui/core/Snackbar";
+import { Alert } from "@material-ui/lab";
+
+import { SnackbarContext } from "../../providers/SnackbarProvider";
+
+export const SimpleSnackbar = () => {
+  const { snackState, setSnackState } = useContext(SnackbarContext); //これで呼び出す
+
+  const handleClose = () => {
+    setSnackState({
+      isOpen: false,
+      type: "success",
+      message: "",
+    });
+  };
+
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: "top",
+        horizontal: "center",
+      }}
+      open={snackState.isOpen}
+      autoHideDuration={4000}
+      onClose={handleClose}
+    >
+      <Alert onClose={handleClose} severity={snackState.type}>
+        {snackState.message}
+      </Alert>
+    </Snackbar>
+  );
+};

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,6 +1,118 @@
 import React, { VFC } from "react";
-import { Link } from "react-router-dom";
+import Avatar from "@material-ui/core/Avatar";
+import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import Container from "@material-ui/core/Container";
+import { useForm, Controller } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+
+import { auth } from "../../firebase";
+import { SubmitHandler } from "react-hook-form";
+import { Link, useHistory } from "react-router-dom";
+import { InputFields } from "../../types/Signup";
+import { formStyles } from "../../styles/LoginAndSignup";
+import { loginSchema } from "../../validators/Login";
+import { useContext } from "react";
+import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const Login: VFC = () => {
-  return <Link to="/signup">新規登録画面はこちら</Link>;
+  const history = useHistory();
+  const classes = formStyles();
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<InputFields>({
+    resolver: yupResolver(loginSchema),
+  });
+
+  const { setSnackState } = useContext(SnackbarContext);
+
+  //ログイン処理
+  const formSubmitHandler: SubmitHandler<InputFields> = async (
+    user: InputFields
+  ) => {
+    try {
+      await auth.signInWithEmailAndPassword(user.email, user.password);
+      setSnackState({
+        isOpen: true,
+        type: "success",
+        message: "ログインしました。",
+      });
+      history.push("/userList");
+    } catch (error) {
+      setSnackState({
+        isOpen: true,
+        type: "error",
+        message: "ログインできませんでした",
+      });
+    }
+  };
+
+  return (
+    <Container component="main" maxWidth="sm">
+      <div className={classes.paper}>
+        <Avatar className={classes.avatar} />
+        <Typography component="h1" variant="h5">
+          ログイン画面
+        </Typography>
+        <form
+          className={classes.form}
+          noValidate
+          autoComplete="off"
+          onSubmit={handleSubmit(formSubmitHandler)}
+        >
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <Controller
+                name="email"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    label="メールアドレス"
+                    variant="outlined"
+                    error={!!errors.email}
+                    helperText={errors.email ? errors.email.message : ""}
+                    fullWidth
+                  />
+                )}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <Controller
+                name="password"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    label="パスワード"
+                    variant="outlined"
+                    type="password"
+                    error={!!errors.password}
+                    helperText={errors.password ? errors.password.message : ""}
+                    fullWidth
+                  />
+                )}
+              />
+            </Grid>
+          </Grid>
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            color="primary"
+            className={classes.submit}
+          >
+            ログイン
+          </Button>
+          <Typography>
+            <Link to="/signup">新規登録はこちらから</Link>
+          </Typography>
+        </form>
+      </div>
+    </Container>
+  );
 };

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -1,20 +1,18 @@
-import React, { VFC } from "react";
+import React, { VFC, useContext } from "react";
 import Avatar from "@material-ui/core/Avatar";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Container from "@material-ui/core/Container";
-import { useForm, Controller } from "react-hook-form";
+import { useForm, Controller, SubmitHandler } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { Link, useHistory } from "react-router-dom";
 
 import { auth } from "../../firebase";
-import { SubmitHandler } from "react-hook-form";
-import { Link, useHistory } from "react-router-dom";
-import { InputFields } from "../../types/Signup";
+import { InputFields } from "../../types/Login";
 import { formStyles } from "../../styles/LoginAndSignup";
 import { loginSchema } from "../../validators/Login";
-import { useContext } from "react";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const Login: VFC = () => {

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -7,12 +7,14 @@ import Typography from "@material-ui/core/Typography";
 import Container from "@material-ui/core/Container";
 import { SubmitHandler, useForm, Controller } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 
-import { db } from "../../firebase";
+import { auth, db } from "../../firebase";
 import { formStyles } from "../../styles/LoginAndSignup";
 import { signupSchema } from "../../validators/Signup";
 import { InputFields } from "../../types/Signup";
+import { useContext } from "react";
+import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const Signup: VFC = () => {
   const classes = formStyles();
@@ -25,15 +27,43 @@ export const Signup: VFC = () => {
     resolver: yupResolver(signupSchema),
   });
 
+  const { setSnackState } = useContext(SnackbarContext);
+
   //fireStoreへのユーザー新規登録処理
   const formSubmitHandler: SubmitHandler<InputFields> = async (
     newUser: InputFields
   ) => {
     try {
-      await db.collection("users").add(newUser);
-      history.push("/userList");
+      //まずは、Authenticationにユーザー登録
+      const result = await auth.createUserWithEmailAndPassword(
+        newUser.email,
+        newUser.password
+      );
+
+      //Authenticationに登録されたユーザーのUID（ユーザーID）を取得
+      const createdUser = result.user;
+      if (createdUser) {
+        const createdUserId = createdUser.uid;
+
+        //FirestoreにuidをドキュメントIDとして持ったユーザーを登録
+        await db
+          .collection("users")
+          .doc(createdUserId)
+          .set({ name: newUser.userName, wallet: 0 });
+
+        setSnackState({
+          isOpen: true,
+          type: "success",
+          message: "ユーザー作成に成功しました。",
+        });
+        history.push("/");
+      }
     } catch (error) {
-      alert(error.message);
+      setSnackState({
+        isOpen: true,
+        type: "error",
+        message: "ユーザー作成に失敗しました。",
+      });
     }
   };
 
@@ -110,6 +140,9 @@ export const Signup: VFC = () => {
           >
             新規登録
           </Button>
+          <Typography>
+            <Link to="/">ログインはこちらから</Link>
+          </Typography>
         </form>
       </div>
     </Container>

--- a/src/components/pages/Signup.tsx
+++ b/src/components/pages/Signup.tsx
@@ -1,4 +1,4 @@
-import React, { VFC } from "react";
+import React, { VFC, useContext } from "react";
 import Avatar from "@material-ui/core/Avatar";
 import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
@@ -13,7 +13,6 @@ import { auth, db } from "../../firebase";
 import { formStyles } from "../../styles/LoginAndSignup";
 import { signupSchema } from "../../validators/Signup";
 import { InputFields } from "../../types/Signup";
-import { useContext } from "react";
 import { SnackbarContext } from "../../providers/SnackbarProvider";
 
 export const Signup: VFC = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,4 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
-);
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/src/providers/LoginUserProvider.tsx
+++ b/src/providers/LoginUserProvider.tsx
@@ -1,0 +1,49 @@
+import React, {
+  createContext,
+  ReactNode,
+  useState,
+  VFC,
+  useEffect,
+} from "react";
+import firebase from "firebase/app";
+
+import { auth, db } from "../firebase";
+
+type LoginUserContextType = {
+  loginUser: LoginUser | null;
+};
+
+type LoginUser = {
+  userName: string;
+  wallet: number;
+};
+
+export const LoginUserContext = createContext({} as LoginUserContextType);
+
+export const LoginUserProvider: VFC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [loginUser, setLoginUser] = useState<LoginUser | null>(null);
+
+  useEffect(() => {
+    const getUserData = async (user: firebase.User | null) => {
+      if (!user) return null;
+
+      const userDoc = await db.collection("users").doc(user.uid).get();
+      const userData = userDoc.data() as LoginUser;
+      return userData;
+    };
+
+    const unSub = auth.onAuthStateChanged(async (user) => {
+      const loginUser = await getUserData(user);
+      setLoginUser(loginUser);
+    });
+    return unSub;
+  }, []);
+
+  return (
+    <LoginUserContext.Provider value={{ loginUser }}>
+      {children}
+    </LoginUserContext.Provider>
+  );
+};

--- a/src/providers/LoginUserProvider.tsx
+++ b/src/providers/LoginUserProvider.tsx
@@ -13,6 +13,7 @@ type LoginUserContextType = {
   loginUser: LoginUser | null;
 };
 
+//ログインユーザー情報
 type LoginUser = {
   userName: string;
   wallet: number;
@@ -26,6 +27,7 @@ export const LoginUserProvider: VFC<{ children: ReactNode }> = ({
   const [loginUser, setLoginUser] = useState<LoginUser | null>(null);
 
   useEffect(() => {
+    //firestoreにもつユーザー情報の取得
     const getUserData = async (user: firebase.User | null) => {
       if (!user) return null;
 

--- a/src/providers/SnackbarProvider.tsx
+++ b/src/providers/SnackbarProvider.tsx
@@ -1,0 +1,37 @@
+import React, {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useState,
+  VFC,
+} from "react";
+
+type SnackState = {
+  isOpen: boolean;
+  type: "success" | "error" | "warning" | "info";
+  message: string;
+};
+
+type SnackbarContextType = {
+  snackState: SnackState;
+  setSnackState: Dispatch<SetStateAction<SnackState>>;
+};
+
+export const SnackbarContext = createContext({} as SnackbarContextType);
+
+export const SnackbarProvider: VFC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [snackState, setSnackState] = useState<SnackState>({
+    isOpen: false,
+    type: "info",
+    message: "",
+  });
+
+  return (
+    <SnackbarContext.Provider value={{ snackState, setSnackState }}>
+      {children}
+    </SnackbarContext.Provider>
+  );
+};

--- a/src/types/Login.ts
+++ b/src/types/Login.ts
@@ -1,0 +1,5 @@
+//入力フィールドの型定義
+export type InputFields = {
+  email: string;
+  password: string;
+};

--- a/src/validators/Login.ts
+++ b/src/validators/Login.ts
@@ -1,0 +1,7 @@
+import * as yup from "yup";
+
+//ログインバリデーションの設定
+export const loginSchema = yup.object().shape({
+  email: yup.string().email().required(),
+  password: yup.string().min(6).max(20).required(),
+});

--- a/src/validators/Signup.ts
+++ b/src/validators/Signup.ts
@@ -4,5 +4,5 @@ import * as yup from "yup";
 export const signupSchema = yup.object().shape({
   userName: yup.string().required(),
   email: yup.string().email().required(),
-  password: yup.string().min(4).max(20).required(),
+  password: yup.string().min(6).max(20).required(),
 });


### PR DESCRIPTION
◆ユーザー新規登録処理の微修正
 1. firestoreに保存する内容を修正
 2. パスワードのバリデーション設定の修正
 
◆ログイン処理の追加
1. firebaseのauthenticationを利用
2. ログイン情報をcontextとして保持（ユーザー名とウォレット情報）

◆その他
1. alert使用箇所をmaterial-uiのsnackbarで書き換え 
 
